### PR TITLE
Replace logic in getFormattedWidth with regex equivalent

### DIFF
--- a/src/func/getFormattedWidth.ts
+++ b/src/func/getFormattedWidth.ts
@@ -8,7 +8,10 @@ export default function getFormattedWidth(unformattedText: string, ctx: CanvasRe
 	// Add extra width for bold characters. The bold modifier continues over line breaks
 	const boldSubstrings = unformattedText.match(/&l(.*?)(?:&r|$)/gs);
 	if (boldSubstrings) {
-		for (const substring of boldSubstrings) {
+		for (let substring of boldSubstrings) {
+			// Replace formatting strings left in the bold text to calculate extra width
+			substring = substring.replaceAll(getSupportedModifiers(), "");
+
 			formattedWidth += substring.length * fontOffset;
 		}
 	}

--- a/src/func/getFormattedWidth.ts
+++ b/src/func/getFormattedWidth.ts
@@ -6,7 +6,7 @@ export default function getFormattedWidth(unformattedText: string, ctx: CanvasRe
 	let formattedWidth = 0;
 
 	// Add extra width for bold characters. The bold modifier continues over line breaks
-	const boldSubstrings = unformattedText.match(/&l(.*?)(?:&r|s$)/gms);
+	const boldSubstrings = unformattedText.match(/&l(.*?)(?:&r|$)/gs);
 	if (boldSubstrings) {
 		for (const substring of boldSubstrings) {
 			formattedWidth += substring.length * fontOffset;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ setCanvasDimensions(text, ctx);
 ctx.font = font;
 renderText(text, ctx);
 
-// At last, save the final image
+// Save the final image
 saveImage(canvas);

--- a/src/util/getSupportedModifiers.ts
+++ b/src/util/getSupportedModifiers.ts
@@ -1,0 +1,3 @@
+export default function getSupportedModifiers() {
+	return /&0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|l|r/g;
+}

--- a/src/util/getSupportedModifiers.ts
+++ b/src/util/getSupportedModifiers.ts
@@ -1,3 +1,3 @@
 export default function getSupportedModifiers() {
-	return /&0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|l|r/g;
+	return /&(?:0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|l|r)/g;
 }


### PR DESCRIPTION
As of yet, the regex for finding all bold substrings within the text is not complete